### PR TITLE
drop forwarding OWM-data to non-existing OWM-server

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -10,7 +10,7 @@
 // Berliner Firmware-Downloads
 
 // http://util.berlin.freifunk.net/update_node/
-// Berliner OWM-Endpoint (z.Zt. Weiterleitung zu openwifimap.net)
+// Berliner OWM-Endpoint
 </pre>
 Du kannst <a href="https://github.com/freifunk-berlin/util.berlin.freifunk.net">auf Github</a> zu dieser Software beitragen und &Auml;nderungen besprechen.
 </body>

--- a/www/update_node.php
+++ b/www/update_node.php
@@ -12,25 +12,4 @@ rename($filename . ".json_new", $filename . ".json");
 if(!is_file($filename . ".ctime")) {
   touch($filename . ".ctime");
 }
-
-$options = array(
-  'http' => array(
-    'method'  => 'PUT',
-    'content' => $entityBody,
-    'header'=>  "Content-Type: application/json\r\n" .
-                "Accept: application/json\r\n"
-    )
-);
-$context  = stream_context_create( $options );
-$result = file_get_contents( "http://api.openwifimap.net/update_node/".$nodename, false, $context );
-foreach($http_response_header as $k=>$v) {
-  if(preg_match("#HTTP/[0-9\.]+\s+([0-9]+)#", $v, $out)) {
-    $code = intval($out[1]);
-    http_response_code(intval($out[1]));
-    if($code === 404) {
-      echo "Not found or invalid method";
-    }
-  }
-}
-echo $result;
 ?>


### PR DESCRIPTION
As mentioned in https://github.com/orgs/freifunk-berlin/projects/1 the OWM-API-Server was shut down. So we don't need to try to send the nodes data to it.
Even this script was planned as a proxy for these data, it now became the primary data-store for the data.
