### PR TITLE
add provision for requests ending in .php

### DIFF
--- a/apache/util.conf
+++ b/apache/util.conf
@@ -35,6 +35,14 @@
         RewriteEngine on
         RewriteCond /var/www/util.berlin.freifunk.net/www/%{REQUEST_URI}.php -f
         RewriteRule ^(.*)$ "fcgi://127.0.0.1:9000/var/www/util.berlin.freifunk.net/www/$1.php" [L,P]
+        # we should still allow normal php files to be called and accessed
+        <FilesMatch ".+\.ph(ar|p|tml)$">
+            SetHandler "proxy:fcgi://127.0.0.1:9000"
+        </FilesMatch>
+        <FilesMatch ".+\.phps$">
+            Require all denied
+        </FilesMatch>
+
 
         AddType application/json .json
 


### PR DESCRIPTION
This might not be the cleanest way, but otherwise you could only request php files by removing the .php from the url.

this allows to request e.g.:
https://util.berlin.freifunk.net/line-of-sight.php
and
https://util.berlin.freifunk.net/line-of-sight