### PR TITLE
Add path based redirect

### DIFF
--- a/apache/util.conf
+++ b/apache/util.conf
@@ -54,3 +54,34 @@
         CustomLog /var/log/apache2/util.berlin.freifunk.net-access.log combined
         ErrorLog  /var/log/apache2/util.berlin.freifunk.net-error.log
 </VirtualHost>
+
+<VirtualHost *:443>
+    ServerName ff.berlin
+    ServerAdmin "info@berlin.freifunk.net"
+    SSLEngine on
+    SSLCertificateFile      /etc/letsencrypt/live/ff.berlin/cert.pem
+    SSLCertificateChainFile /etc/letsencrypt/live/ff.berlin/chain.pem
+    SSLCertificateKeyFile   /etc/letsencrypt/live/ff.berlin/privkey.pem
+
+    DocumentRoot /var/www/util.berlin.freifunk.net/www
+
+    <Directory /var/www/util.berlin.freifunk.net/www>
+            Options +FollowSymLinks -Indexes
+            AllowOverride None
+            Require all granted
+    </Directory>
+
+    # Always call the knoteninfo.php script
+    DirectoryIndex knoteninfo.php
+
+    # Deny access to all other PHP files
+    <FilesMatch "\.php$">
+        Require all denied
+    </FilesMatch>
+    <Files "knoteninfo.php">
+        Require all granted
+    </Files>
+
+    CustomLog /var/log/apache2/ff.berlin-access.log combined
+    ErrorLog  /var/log/apache2/ff.berlin-error.log
+</VirtualHost>

--- a/www/knoteninfo.php
+++ b/www/knoteninfo.php
@@ -1,14 +1,56 @@
 <?php
 
-// https://util.berlin.freifunk.net/knoteninfo?knoten=Zwingli-Nord-2GHz&typ=wiki
+// Query based redirect
+// Example: https://util.berlin.freifunk.net/knoteninfo?knoten=Zwingli-Nord-2GHz&typ=wiki
 // typ: wiki, monitor, owm, hopglass
+//
+// Path based redirect
+// Example: https://ff.berlin/d/linie206-core
+// /d/ -> documentation (wiki)
+// /m/ -> map (hopglass)
+// /s/ -> statistics (monitor)
 
-$knoten = ($_GET["knoten"] ?? "%");
+$path_elements = getPathElements($_SERVER['REQUEST_URI'], $_SERVER['SCRIPT_NAME']);
+
+if (count($_GET)) {
+  $knoten = ($_GET["knoten"] ?? "%");
+  $typ = ($_GET["typ"] ?? "");
+} else if (count($path_elements) == 2) {
+  switch ($path_elements[0]) {
+    case "d":
+      $typ = "wiki";
+      break;
+    case "m":
+      $typ = "hopglass";
+      break;
+    case "s":
+      $typ = "monitor";
+      break;
+  }
+  ;
+  $knoten = $path_elements[1];
+} else {
+  die("Keine gültige Anfrage.");
+}
+
 $knoten = preg_replace("/\.olsr$/", "", $knoten);
 
 if(preg_match('/[^A-Za-z0-9\\.\\-\\_]/', $knoten)) die("Ungültiger Knotenname.");
 
-$typ = ($_GET["typ"] ?? "");
+
+function getPathElements($request_uri, $script_name) {
+  
+  if (strpos($request_uri, $script_name) === 0) {
+    $request_path = substr($request_uri, strlen($script_name));
+  } else {
+    $request_path = $request_uri;
+  }
+  
+  $parsed_url = parse_url($request_path);
+  $path = $parsed_url['path'];
+  return explode('/', trim($path, '/'));
+}
+
 
 function getUrl($url) {
   $ctx = stream_context_create(["http" => ["method" => "GET"]]);
@@ -18,7 +60,8 @@ function getUrl($url) {
   return $res;
 }
 
-function getWikiLink($knoten) {
+
+function getWikiLink($knoten){
   $url = "https://wiki.freifunk.net/api.php?action=ask&query=[[Hat_Knoten%3A%3A".$knoten."]]|%3FModification%20date|sort%3DModification%20date|order%3Ddesc&format=json";
   $body = getUrl($url);
   $json = json_decode($body);
@@ -56,11 +99,11 @@ if($typ === "wiki") {
 
 echo "<i>$knoten</i> auf...";
 echo "<ul>".
-     "<li><a href=\"$owmurl\">openwifimap.net</a></li>".
-     "<li><a href=\"$hgurl\">hopglass.berlin.freifunk.net</a></li>".
-     "<li><a href=\"/knoteninfo?knoten=$knoten&typ=wiki\">wiki.freifunk.net</a></li>".
-     "<li><a href=\"$monurl\">monitor.berlin.freifunk.net</a></li>".
-     "</ul>".
-     "zu <a href=\"https://berlin.freifunk.net/\">berlin.freifunk.net</a></body>";
+  "<li><a href=\"$owmurl\">openwifimap.net</a></li>".
+  "<li><a href=\"$hgurl\">hopglass.berlin.freifunk.net</a></li>".
+  "<li><a href=\"/knoteninfo?knoten=$knoten&typ=wiki\">wiki.freifunk.net</a></li>".
+  "<li><a href=\"$monurl\">monitor.berlin.freifunk.net</a></li>".
+  "</ul>".
+  "zu <a href=\"https://berlin.freifunk.net/\">berlin.freifunk.net</a></body>";
 
 ?>


### PR DESCRIPTION
Added a shorter path based redirect to `knoteninfo`.  Before you needed to type e.g. `https://util.berlin.freifunk.net/knoteninfo?knoten=linie206-core&typ=wiki` to get a redirect to the wiki based on the node name. Now you can use `ff.berlin/d/linie206-core`. These are two improvements:
1. Links are shorter. That way they can even be written on a device for documentation (see [ff-sticker](https://github.com/freifunk-berlin/meta/issues/17)).
2. Links are more generic. We don't write which service exactly we want (e.g. wiki for documentation) but say that we want the documentation of the node. Then you will be redirected to the service we currently use for it. Making it easy to migrate to an other service in the future.
```
d (documentation) -> wiki
m (map) -> hopglass
s (statistics) -> monitor
```